### PR TITLE
support linting multiple trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ If true it will generate tests for both passing and failing tests, overrides the
 
 If true it will disable logging of errors to console
 
+`includePaths` {array of strings}
+
+Paths representing trees to lint. The app tree itself will always be included.
+In an addon, that path is `tests/dummy/app/styles/` (by default). Addon authors
+can set `includePaths: [ 'app/styles' ]` to also lint styles in `app/styles/`.
+
 ## Running Tests
 
 * `npm test`

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 'use strict';
 
+var mergeTrees = require('broccoli-merge-trees');
 var StyleLinter = require('broccoli-stylelint');
 
 module.exports = {
@@ -50,7 +51,17 @@ module.exports = {
           errorMessage: errors
         }]);
       };
-      return new StyleLinter(this.app.trees.app, this.styleLintOptions);
+
+      var toBeLinted = [ this.app.trees.app ];
+      if (this.styleLintOptions.includePaths) {
+        toBeLinted.push.apply(toBeLinted, this.styleLintOptions.includePaths);
+      }
+
+      var linted = toBeLinted.map(function(tree) {
+        return new StyleLinter(tree, this.styleLintOptions);
+      }, this);
+
+      return mergeTrees(linted);
     } else {
       return tree;
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "dependencies": {
     "broccoli-funnel": "1.0.1",
+    "broccoli-merge-trees": "^1.2.1",
     "broccoli-stylelint": "0.10.1",
     "ember-cli-babel": "5.1.6"
   },


### PR DESCRIPTION
 * Add broccoli-merge-trees
 * Add an `includePaths` configuration option to specify paths to be linted _in addition to the app tree_.A
 * Add documenation for `includePaths` with special attention to supporting addon authors.

Fixes #41