### PR TITLE
deep-copy options before passing to each StyleLint tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 var mergeTrees = require('broccoli-merge-trees');
 var StyleLinter = require('broccoli-stylelint');
+var deepcopy = require('deepcopy');
 
 module.exports = {
   name: 'ember-cli-stylelint',
@@ -58,7 +59,8 @@ module.exports = {
       }
 
       var linted = toBeLinted.map(function(tree) {
-        return new StyleLinter(tree, this.styleLintOptions);
+        // copy options because StyleLinter mutates them
+        return new StyleLinter(tree, deepcopy(this.styleLintOptions));
       }, this);
 
       return mergeTrees(linted);

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "broccoli-funnel": "1.0.1",
     "broccoli-merge-trees": "^1.2.1",
     "broccoli-stylelint": "0.10.1",
+    "deepcopy": "^0.6.3",
     "ember-cli-babel": "5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
The broccoli-stylelint StyleLint constructor mutates its `options`, so we can't pass the same `options` object to each instance.

Resolves #45