### PR TITLE
Include app tree option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Paths representing trees to lint. The app tree itself will always be included.
 In an addon, that path is `tests/dummy/app/styles/` (by default). Addon authors
 can set `includePaths: [ 'app/styles' ]` to also lint styles in `app/styles/`.
 
+`includeAppTree` {boolean}
+
+If false it will not automatically include the app tree. Make sure you add paths to `includePaths` if you set this to false.
+
 ## Running Tests
 
 * `npm test`

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
     var project = this.project;
 
     if (type === 'app') {
-      this.styleLintOptions.testGenerator =  function(relativePath, errors) {
+      this.styleLintOptions.testGenerator = function(relativePath, errors) {
         var passed = null;
         var name = relativePath+' should pass style lint';
         if (errors) {
@@ -63,7 +63,7 @@ module.exports = {
       }
 
       if (toBeLinted.length === 0) {
-        console.warn('No paths to lint, ensure includePaths is set if includeAppTree is false.');
+        console.warn('No paths to lint, try setting includePaths.');
       }
 
       var linted = toBeLinted.map(function(tree) {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ module.exports = {
         toBeLinted.push.apply(toBeLinted, this.styleLintOptions.includePaths);
       }
 
+      if (toBeLinted.length === 0) {
+        console.warn('No paths to lint, ensure includePaths is set if includeAppTree is false.');
+      }
+
       var linted = toBeLinted.map(function(tree) {
         return new StyleLinter(tree, this.styleLintOptions);
       }, this);

--- a/index.js
+++ b/index.js
@@ -52,7 +52,12 @@ module.exports = {
         }]);
       };
 
-      var toBeLinted = [ this.app.trees.app ];
+      var toBeLinted = [];
+
+      if (this.styleLintOptions.includeAppTree !== false) {
+        toBeLinted.push(this.app.trees.app);
+      }
+
       if (this.styleLintOptions.includePaths) {
         toBeLinted.push.apply(toBeLinted, this.styleLintOptions.includePaths);
       }

--- a/tests/dummy/app/styles/some_module/index.scss
+++ b/tests/dummy/app/styles/some_module/index.scss
@@ -1,0 +1,3 @@
+.color.must.be.named {
+  color: #000000
+}

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -67,7 +67,7 @@ describe('ember-cli-stylelint', function() {
     });
   });
 
-  it('should not include app tree by default if includeAppTree is false', function() {
+  it('The app tree is excluded if includeAppTree is false', function() {
     var options = {
       includeAppTree: false,
       includePaths: [ 'tests/dummy/app/styles/some_module' ]

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -7,16 +7,18 @@ var assert = chai.assert;
 
 var builder, errors;
 
-function buildAndLint(sourcePath) {
+function buildAndLint(sourcePath, options) {
+  var defaultOptions = {
+    onError: function(results) {
+      errors.push(results);
+    },
+    console: console
+  };
+
   linter.included({
     isTestingStyleLintAddon: true,
     options: {
-      stylelint:{
-        onError: function(results) {
-          errors.push(results);
-        },
-        console:console
-      }
+      stylelint: Object.assign({}, defaultOptions, options)
     },
     trees: {
       app: sourcePath, // Directory to lint
@@ -46,15 +48,42 @@ describe('ember-cli-stylelint', function() {
   it('The linter should run', function() {
     return buildAndLint('tests/dummy').then(function() {
       var firstError = errors[0];
+      var secondError = errors[1];
 
       assert.ok(!!firstError,
+        'The linting should occur');
+      assert.ok(!!secondError,
         'The linting should occur');
 
       assert.equal(firstError.source, 'app/styles/app.scss',
         'The app.scss file should be linted');
+      assert.equal(secondError.source, 'app/styles/some_module/index.scss',
+        'The some_module/index.scss file should be linted');
 
       assert.ok(firstError.warnings.length === 2,
         'Found correct amount of errors');
+      assert.ok(secondError.warnings.length === 1,
+        'Found correct amount of errors');
     });
+  });
+
+  it('should not include app tree by default if includeAppTree is false', function() {
+    var options = {
+      includeAppTree: false,
+      includePaths: [ 'tests/dummy/app/styles/some_module' ]
+    };
+    return buildAndLint('tests/dummy', options)
+      .then(function() {
+        var firstError = errors[0];
+
+        assert.ok(!!firstError,
+          'The linting should occur');
+
+        assert.equal(firstError.source, 'index.scss',
+          'The app.scss file should not be linted');
+
+        assert.equal(firstError.warnings.length, 1,
+          'Found correct amount of errors');
+      });
   });
 });


### PR DESCRIPTION
fixes https://github.com/billybonks/ember-cli-stylelint/issues/53

Optionally exclude the default app tree so you can explicitly set paths in `includePaths`.