### PR TITLE
Prevent pass-through `app/**/*.js` in tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 var mergeTrees = require('broccoli-merge-trees');
 var StyleLinter = require('broccoli-stylelint');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-stylelint',
@@ -73,7 +74,10 @@ module.exports = {
       }
 
       var linted = toBeLinted.map(function(tree) {
-        return new StyleLinter(tree, this.styleLintOptions);
+        var filteredTreeToBeLinted = new Funnel(tree, { 
+          exclude: ['**/*.js']
+        });
+        return new StyleLinter(filteredTreeToBeLinted, this.styleLintOptions);
       }, this);
 
       return mergeTrees(linted);


### PR DESCRIPTION
`broccoli-stylelint` processes `.less`, `.scss`, `.sss`, and `.css` files in the provided input trees and convert them into `.stylelint-test.js` files. Any other files (e.g. `*.js`) files, are "passed through" untouched (this is  normal `broccoli-filter`/`broccoli-persistent-filter` behavior).

Unfortunately, the result of this means that any modules in the `app/` tree, end up in **both** `assets/app-name.js` **and** `assets/tests.js` (because `lintTree` results go into `tests.js`). 

Prior to ember-cli@2.13, this situation worked fine because we fully transpiled the results of `lintTree`, but as of ember-cli@2.13 we only transpile modules down to AMD (no other transpilation).

---

Fixes #68 
Fixes #65 
Fixes #63 
