### PR TITLE
Convert `ember-cli-babel` to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-babel": "5.1.6",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
@@ -67,8 +68,7 @@
   "dependencies": {
     "broccoli-funnel": "1.1.0",
     "broccoli-merge-trees": "^1.2.1",
-    "broccoli-stylelint": "1.0.0",
-    "ember-cli-babel": "5.1.6"
+    "broccoli-stylelint": "1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
`ember-cli-babel` does not seem to be used by this addon as the `app` and `addon` folders are essentially empty. This will allow users of this addon to drop `ember-cli-shims` as that requires that all used addons use at least v6.6.0 of `ember-cli-babel`.

/cc @billybonks 