### PR TITLE
Use caret version constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "broccoli": "0.16.9",
+    "broccoli": "^0.16.9",
     "broccoli-asset-rev": "^2.4.5",
-    "chai": "3.5.0",
+    "chai": "^3.5.0",
     "ember-cli": "~2.18.0",
-    "ember-cli-babel": "~6.7.1",
-    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-babel": "^6.7.1",
+    "ember-cli-content-security-policy": "^0.4.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
@@ -49,7 +49,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",
-    "mocha": "3.0.0"
+    "mocha": "^3.0.0"
   },
   "keywords": [
     "ember-addon",
@@ -66,9 +66,9 @@
     "css-lint"
   ],
   "dependencies": {
-    "broccoli-funnel": "1.1.0",
+    "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",
-    "broccoli-stylelint": "1.1.0"
+    "broccoli-stylelint": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR adjusts all dependencies to use caret version constraints so that PRs like #77 should be unnecessary in the future.