### PR TITLE
Convert `ember-cli-babel` to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "chai": "^3.5.0",
     "ember-cli": "~3.0.1",
+    "ember-cli-babel": "^6.7.1",
     "ember-cli-content-security-policy": "^0.4.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
@@ -71,7 +72,6 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",
     "broccoli-stylelint": "^2.0.0",
-    "ember-cli-babel": "^6.7.1",
     "js-string-escape": "^1.0.1"
   },
   "ember-addon": {


### PR DESCRIPTION
`ember-cli-babel` does not seem to be used by this addon as the `app` and `addon` folders are essentially empty.

see #76 

/cc @billybonks 