### PR TITLE
update scenarios

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x]
         ember-version:
           - release
           - beta
@@ -24,6 +24,7 @@ jobs:
           - lts-3.4
           - lts-3.8
           - lts-3.12
+          - lts-3.16
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -52,6 +52,15 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-lts-3.16',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.16.0',
+              'ember-cli': '~3.16.0',
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Drop node 13 since ember-cli doesn't support it.
Add 3.16-lts to test suites