### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@
 [![downloads](https://img.shields.io/npm/dm/ember-cli-stylelint.svg)](https://www.npmjs.com/package/ember-cli-stylelint)
 [![build](https://travis-ci.org/billybonks/ember-cli-stylelint.svg?branch=master)](https://travis-ci.org/billybonks/ember-cli-stylelint/branches)
 
-Installation
-------------------------------------------------------------------------------
-
 # ember-cli-stylelint
 
 An Ember-CLI addon that allows easy integration with [stylelint](http://stylelint.io/)
+
+## 🔴 DEPRECATED 🔴
+
+Please use [stylelint](https://github.com/stylelint/stylelint) directly instead.
+
+More info / background:
+
+* https://github.com/ember-cli/rfcs/pull/121
+* https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md
+* https://github.com/ember-cli/ember-cli/pull/9009
 
 ## Installation
 


### PR DESCRIPTION
Using the ember-cli linting plugins has been deprecated for years based on the RFC linked to below. ember-cli-eslint and ember-cli-template-lint have already been marked deprecated and have deprecation notices in their READMEs as linked to below.

In this PR, I'm proposing/implementing a deprecation notice suggesting to use stylelint directly instead. If this is accepted, the maintainer should also run the following command to mark the package as deprecated in the NPM registry:

```
npm deprecate ember-cli-stylelint "Use stylelint directly instead: https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md"
```

By using stylelint directly, we mean that Ember apps should tell their CI to run their `lint` script the same way it runs their `test` script. The lint scripts in package.json usually look roughly like this in Ember apps (simplified version from [ember-cli blueprint](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/package.json)):

```
"lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
"lint:css": "stylelint .",
"lint:hbs": "ember-template-lint .",
"lint:js": "eslint .",
```

More info:

* https://github.com/ember-cli/rfcs/pull/121
* https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md
* https://github.com/ember-cli/ember-cli/pull/9009
* https://github.com/ember-cli/ember-cli-eslint/pull/597
* https://github.com/ember-cli/ember-cli-eslint#-deprecated-
* https://github.com/ember-template-lint/ember-cli-template-lint#-deprecated-
* https://www.npmjs.com/package/ember-cli-eslint
* https://www.npmjs.com/package/ember-cli-template-lint